### PR TITLE
Refactor of code to get it working

### DIFF
--- a/qubole-aws-terraform-deployment/qubole-deployment/main.tf
+++ b/qubole-aws-terraform-deployment/qubole-deployment/main.tf
@@ -1,6 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 2.0"
-  region  = "ap-southeast-1"
+  region  = "us-east-1"
 }
 
 resource "random_id" "deployment_suffix" {
@@ -79,15 +87,14 @@ output "hive_metastore_ip" {
 
 output "hive_metastore_user" {
   value = module.hive_metastore.hive-metastore-db-user
+  sensitive = true
 }
 
 output "hive_metastore_password" {
   value = module.hive_metastore.hive-metastore-db-password
+  sensitive = true
 }
 
 output "hive_metastore_db_name" {
   value = module.hive_metastore.hive-metastore-db-name
 }
-
-
-

--- a/qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/aws_db_instance_hive_metastore.tf
+++ b/qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/aws_db_instance_hive_metastore.tf
@@ -17,14 +17,15 @@ Creates an RDS Instance to host the Hive Metastore. It
 resource "aws_db_instance" "hive_metastore_db_instance" {
   identifier = "hive-metastore-db-${var.deployment_suffix}"
   allocated_storage = 20
-  storage_type = "gp2"
+  storage_type = "gp3"
+  #iops = 3000  #update the iops to 3000 for storage less than 400GB if error is thrown regarding RDS storage or IOPs
   engine = "mysql"
-  engine_version = "5.7"
+  engine_version = "8.0.41"
   instance_class = var.db_instance_class
   name = "hive"
   username = var.hive_user_name
   password = var.hive_user_password
-  parameter_group_name = "default.mysql5.7"
+  parameter_group_name = "default.mysql8.0"
   apply_immediately = true
   db_subnet_group_name = aws_db_subnet_group.hive_metastore_subnet_group.name
   publicly_accessible = false

--- a/qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/scripts/shell/init_hive_metastore.sh
+++ b/qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/scripts/shell/init_hive_metastore.sh
@@ -5,8 +5,8 @@ sudo yum install -y mysql
 echo ">>>> Proceeding with Hive Metastore init"
 echo ">>>> Downloading required SQL from Github"
 
-wget https://raw.githubusercontent.com/apache/hive/master/metastore/scripts/upgrade/mysql/hive-schema-2.1.0.mysql.sql
-wget https://raw.githubusercontent.com/apache/hive/master/metastore/scripts/upgrade/mysql/hive-txn-schema-2.1.0.mysql.sql
+wget https://raw.githubusercontent.com/apache/hive/refs/tags/rel/release-2.1.1/metastore/scripts/upgrade/mysql/hive-schema-2.1.0.mysql.sql
+wget https://raw.githubusercontent.com/apache/hive/refs/tags/rel/release-2.1.1/metastore/scripts/upgrade/mysql/hive-txn-schema-2.1.0.mysql.sql
 
 echo ">>>> Checking if Hive is already initialized"
 if [ $(mysql -N -s -u${hive_user_name} -p${hive_user_pass} -h${hive_db_host} -e "select count(*) from information_schema.tables where table_schema='${hive_db_name}' and table_name='DBS';") -eq 1 ]; then

--- a/qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/variables.tf
+++ b/qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/variables.tf
@@ -14,7 +14,7 @@ variable "db_secondary_zone" {
 }
 
 variable "db_instance_class" {
-  default = "db.t2.micro"
+  default = "db.t4g.micro"
 }
 
 variable "hive_user_name" {

--- a/qubole-aws-terraform-deployment/qubole-deployment/modules/network_infrastucture/variables.tf
+++ b/qubole-aws-terraform-deployment/qubole-deployment/modules/network_infrastucture/variables.tf
@@ -12,11 +12,11 @@ variable "qubole_public_key" {
 
 variable "qubole_tunnel_nat" {
   type    = list(string)
-  default = ["52.44.223.209/32", "100.25.6.193/32"]
+  default = ["52.44.223.209/32", "100.25.6.193/32", "34.205.91.155/32"]
 }
 
 variable "bastion_ami" {
-  default = "ami-0c3326e0cad1779ba"
+  default = "ami-0083aebf228b93dad"
 }
 
 variable "bastion_instance_type" {


### PR DESCRIPTION
**Module: hive_metastore**

1. qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/scripts/shell/init_hive_metastore.sh – hive metastore schema file URLs updated as old ones are not available.
2. qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/aws_db_instance_hive_metastore.tf  –  storage_type, engine_version, parameter_group_name values updated to reflect gp3 and mysql8 respectively. Also a commented line(line number 21) added for parameter iops to set IOPS to 3000 incase terraform apply is rerun upon failure and error is thrown with regards to storage/iops.
3. qubole-aws-terraform-deployment/qubole-deployment/modules/hive_metastore/variables.tf  –  db_instance_class was changed to "db.t4g.micro" since the initial one is not available on AWS.



**Module: network_infrastructure**

1. qubole-aws-terraform-deployment/qubole-deployment/modules/network_infrastucture/variables.tf  –  qubole_tunnel_nat variable updated by adding tunnel NAT for [api.qubole.com](http://api.qubole.com/). Also bastion_ami updated to the latest being used.



**Main**

**qubole-aws-terraform-deployment/qubole-deployment/main.tf**

1. terraform block added from line 1 to 8 to reflect current terraform version 2.0 syntax.
2. provider block updated by removing version parameter.
3. hive_metastore_user block updated by adding sensitive parameter since it’s a credential.
4. hive_metastore_password block updated by adding sensitive parameter since it’s a credential.